### PR TITLE
[Feat] Integrate team page with API (partial)

### DIFF
--- a/src/api/group.api.ts
+++ b/src/api/group.api.ts
@@ -1,0 +1,7 @@
+import axiosInstance from '@/api/axiosInstance';
+import { Group } from '@/types/grouptypes';
+
+export const getGroupDetail = async (groupId: number): Promise<Group> => {
+  const response = await axiosInstance.get(`/groups/${groupId}`);
+  return response.data;
+};

--- a/src/api/tasklist.api.ts
+++ b/src/api/tasklist.api.ts
@@ -1,8 +1,20 @@
 import axiosInstance from '@/api/axiosInstance';
+import { Task } from '@/types/tasktypes';
 
 export const createTaskList = async ({ groupId, name }: { groupId: number; name: string }) => {
   const response = await axiosInstance.post(`/groups/${groupId}/task-lists`, {
     name,
+  });
+  return response.data;
+};
+
+export const getTasksByTaskList = async (
+  groupId: number,
+  taskListId: number,
+  date?: string
+): Promise<Task[]> => {
+  const response = await axiosInstance.get(`/groups/${groupId}/task-lists/${taskListId}/tasks`, {
+    params: date ? { date } : {},
   });
   return response.data;
 };

--- a/src/api/tasklist.api.ts
+++ b/src/api/tasklist.api.ts
@@ -1,0 +1,8 @@
+import axiosInstance from '@/api/axiosInstance';
+
+export const createTaskList = async ({ groupId, name }: { groupId: number; name: string }) => {
+  const response = await axiosInstance.post(`/groups/${groupId}/task-lists`, {
+    name,
+  });
+  return response.data;
+};

--- a/src/api/user.api.ts
+++ b/src/api/user.api.ts
@@ -1,21 +1,29 @@
 import axiosInstance from '@/api/axiosInstance';
 import { GroupPageInfo } from '@/types/teampagetypes';
+import { Memberships } from '@/types/usertypes';
 /*
 export const getCurrentUser = async () => {
   const response = await axiosInstance.get('/user');
   return response.data;
 };*/
 
-export const getGroupPageInfo = async (): Promise<GroupPageInfo> => {
+export const getGroupPageInfo = async (groupId: string): Promise<GroupPageInfo> => {
   const res = await axiosInstance.get(`/user/memberships`);
-  const membership = res.data?.[0];
+  const memberships: Memberships[] = res.data;
 
-  if (!membership) throw new Error('No group membership found');
+  console.log('🔍 현재 URL groupId:', groupId);
+  console.log(
+    '📦 서버에서 받은 그룹들:',
+    memberships.map((m) => m.group.id)
+  );
+
+  const matched = memberships.find((m) => String(m.group.id) === groupId);
+  if (!matched) throw new Error('No matching group found');
 
   return {
-    role: membership.role,
+    role: matched.role,
     group: {
-      name: membership.group.name,
+      name: matched.group.name,
     },
   };
 };

--- a/src/api/user.api.ts
+++ b/src/api/user.api.ts
@@ -1,21 +1,10 @@
 import axiosInstance from '@/api/axiosInstance';
 import { GroupPageInfo } from '@/types/teampagetypes';
 import { Memberships } from '@/types/usertypes';
-/*
-export const getCurrentUser = async () => {
-  const response = await axiosInstance.get('/user');
-  return response.data;
-};*/
 
 export const getGroupPageInfo = async (groupId: string): Promise<GroupPageInfo> => {
   const res = await axiosInstance.get(`/user/memberships`);
   const memberships: Memberships[] = res.data;
-
-  console.log('🔍 현재 URL groupId:', groupId);
-  console.log(
-    '📦 서버에서 받은 그룹들:',
-    memberships.map((m) => m.group.id)
-  );
 
   const matched = memberships.find((m) => String(m.group.id) === groupId);
   if (!matched) throw new Error('No matching group found');
@@ -23,6 +12,7 @@ export const getGroupPageInfo = async (groupId: string): Promise<GroupPageInfo> 
   return {
     role: matched.role,
     group: {
+      id: matched.group.id,
       name: matched.group.name,
     },
   };

--- a/src/app/(pages)/(main)/[teamid]/page.tsx
+++ b/src/app/(pages)/(main)/[teamid]/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
 import { toast } from 'react-toastify';
-//import { useQuery } from '@tanstack/react-query';
 import { TextInput } from '@/components/common/Inputs';
 import { TasksItem } from '@/components/teampage/TaskElements';
 import TeamHeader from '@/components/teampage/TeamHeader';
@@ -12,12 +11,10 @@ import Member from '@/components/common/Member';
 import Modal from '@/components/common/Modal';
 import { Profile } from '@/components/common/Profiles';
 import { createTaskList } from '@/api/tasklist.api';
-//import { getTasksByTaskList } from '@/api/tasklist.api';
 import { useGroupDetail } from '@/hooks/useGroupDetail';
 import { useGroupPageInfo, useAllTaskListTasks } from '@/hooks/useGroupPageInfo';
 import { useModalGroup } from '@/hooks/useModalGroup';
-//import { TaskList } from '@/types/tasklisttypes';
-//import { TaskInfo } from '@/types/teampagetypes';
+import { getFutureDateString } from '@/utils/date';
 
 const mockMembers = [
   { name: '우지은', email: 'coworkers@code.com' },
@@ -86,8 +83,15 @@ export default function TeamPage() {
   const teamName = userData?.group.name ?? '팀 없음';
   const groupId = userData?.group.id;
   const { data: groupDetail } = useGroupDetail(groupId);
+
+  const [futureDate, setFutureDate] = useState<string | null>(null);
+
+  useEffect(() => {
+    setFutureDate(getFutureDateString(100));
+  }, []);
+
   const taskListIds = groupDetail?.taskLists.map((list) => list.id) ?? [];
-  const taskQueries = useAllTaskListTasks(groupId, taskListIds);
+  const taskQueries = useAllTaskListTasks(groupId, taskListIds, futureDate ?? '');
 
   return (
     <div className="py-6">
@@ -128,6 +132,7 @@ export default function TeamPage() {
           const tasks = taskQuery?.data ?? [];
           const total = tasks.length;
           const completed = tasks.filter((task) => task.doneAt !== null).length;
+          if (!futureDate) return null;
 
           return (
             <TasksItem key={list.id} completed={completed} total={total} tasksTitle={list.name} />

--- a/src/app/(pages)/(main)/[teamid]/page.tsx
+++ b/src/app/(pages)/(main)/[teamid]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
 import { toast } from 'react-toastify';
 import { TextInput } from '@/components/common/Inputs';
 import { TasksItem } from '@/components/teampage/TaskElements';
@@ -61,13 +62,18 @@ export default function TeamPage() {
     open('memberProfile');
   };
 
-  const { data: userData } = useGroupPageInfo();
+  //const groupName = userData?.group.name;
+  const { teamid } = useParams() as { teamid: string };
+  console.log('현재 URL의 teamId (groupId):', teamid);
+  console.log('useParams 전체:', useParams());
+  const { data: userData } = useGroupPageInfo(teamid);
+
   const isAdmin = userData?.role === 'ADMIN';
-  const groupName = userData?.group.name;
+  const teamName = userData?.group.name ?? '팀 없음';
 
   return (
     <div className="py-6">
-      <TeamHeader title={groupName ?? '팀 이름'} showGear={isClient && isAdmin} />
+      <TeamHeader title={teamName} showGear={isClient && isAdmin} />
 
       <section className={sectionStyle}>
         <header className={sectionHeaderStyle}>

--- a/src/app/(pages)/(main)/[teamid]/page.tsx
+++ b/src/app/(pages)/(main)/[teamid]/page.tsx
@@ -12,6 +12,7 @@ import Modal from '@/components/common/Modal';
 import { Profile } from '@/components/common/Profiles';
 import { createTaskList } from '@/api/tasklist.api';
 import { useModalGroup } from '@/hooks/useModalGroup';
+import { useGroupDetail } from '@/hooks/useGroupDetail';
 import { useGroupPageInfo } from '@/hooks/useGroupPageInfo';
 
 const mockMembers = [
@@ -77,10 +78,10 @@ export default function TeamPage() {
 
   const { teamid } = useParams() as { teamid: string };
   const { data: userData } = useGroupPageInfo(teamid);
-
   const isAdmin = userData?.role === 'ADMIN';
   const teamName = userData?.group.name ?? '팀 없음';
   const groupId = userData?.group.id;
+  const { data: groupDetail } = useGroupDetail(groupId);
 
   return (
     <div className="py-6">
@@ -90,7 +91,7 @@ export default function TeamPage() {
         <header className={sectionHeaderStyle}>
           <div className={sectionHeaderTitleStyle}>
             <h2 className={sectionHeaderH2Style}>할 일 목록</h2>
-            <p className={sectionHeaderPSTyle}>(4개)</p>
+            <p className={sectionHeaderPSTyle}>({groupDetail?.taskLists.length ?? 0}개)</p>
           </div>
           {isClient && isAdmin && (
             <button className={sectionHeaderButtonStyle} onClick={() => open('createList')}>
@@ -116,10 +117,9 @@ export default function TeamPage() {
           </Modal>
         </header>
 
-        <TasksItem completed={1} total={3} tasksTitle="할일목록 1" />
-        <TasksItem completed={2} total={5} tasksTitle="할일목록 2" />
-        <TasksItem completed={3} total={7} tasksTitle="할일목록 3" />
-        <TasksItem completed={10} total={10} tasksTitle="할일목록 4" />
+        {groupDetail?.taskLists.map((list) => (
+          <TasksItem key={list.id} completed={1} total={3} tasksTitle={list.name} />
+        ))}
       </section>
 
       <section className={sectionStyle}>

--- a/src/app/(pages)/(main)/[teamid]/page.tsx
+++ b/src/app/(pages)/(main)/[teamid]/page.tsx
@@ -10,6 +10,7 @@ import Report from '@/components/teampage/Report';
 import Member from '@/components/common/Member';
 import Modal from '@/components/common/Modal';
 import { Profile } from '@/components/common/Profiles';
+import { createTaskList } from '@/api/tasklist.api';
 import { useModalGroup } from '@/hooks/useModalGroup';
 import { useGroupPageInfo } from '@/hooks/useGroupPageInfo';
 
@@ -39,11 +40,23 @@ export default function TeamPage() {
 
   const { open, close, isOpen } = useModalGroup<'invite' | 'createList' | 'memberProfile'>();
 
-  const handleCreateList = () => {
+  const handleCreateList = async () => {
     if (!newListName.trim()) return;
-    close();
-    toast.success('새로운 목록이 생성되었습니다.');
-    setNewListName('');
+    if (!groupId || !teamid) return toast.error('그룹 정보를 불러오지 못했습니다.');
+
+    try {
+      await createTaskList({
+        groupId: groupId,
+        name: newListName.trim(),
+      });
+
+      toast.success('새로운 목록이 생성되었습니다.');
+      close();
+      setNewListName('');
+    } catch (error) {
+      toast.error('목록 생성에 실패했습니다.');
+      console.error(error);
+    }
   };
 
   const handleCopyPageLink = async () => {
@@ -62,14 +75,12 @@ export default function TeamPage() {
     open('memberProfile');
   };
 
-  //const groupName = userData?.group.name;
   const { teamid } = useParams() as { teamid: string };
-  console.log('현재 URL의 teamId (groupId):', teamid);
-  console.log('useParams 전체:', useParams());
   const { data: userData } = useGroupPageInfo(teamid);
 
   const isAdmin = userData?.role === 'ADMIN';
   const teamName = userData?.group.name ?? '팀 없음';
+  const groupId = userData?.group.id;
 
   return (
     <div className="py-6">

--- a/src/app/(pages)/(main)/[teamid]/page.tsx
+++ b/src/app/(pages)/(main)/[teamid]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
 import { toast } from 'react-toastify';
+//import { useQuery } from '@tanstack/react-query';
 import { TextInput } from '@/components/common/Inputs';
 import { TasksItem } from '@/components/teampage/TaskElements';
 import TeamHeader from '@/components/teampage/TeamHeader';
@@ -11,9 +12,12 @@ import Member from '@/components/common/Member';
 import Modal from '@/components/common/Modal';
 import { Profile } from '@/components/common/Profiles';
 import { createTaskList } from '@/api/tasklist.api';
-import { useModalGroup } from '@/hooks/useModalGroup';
+//import { getTasksByTaskList } from '@/api/tasklist.api';
 import { useGroupDetail } from '@/hooks/useGroupDetail';
-import { useGroupPageInfo } from '@/hooks/useGroupPageInfo';
+import { useGroupPageInfo, useAllTaskListTasks } from '@/hooks/useGroupPageInfo';
+import { useModalGroup } from '@/hooks/useModalGroup';
+//import { TaskList } from '@/types/tasklisttypes';
+//import { TaskInfo } from '@/types/teampagetypes';
 
 const mockMembers = [
   { name: '우지은', email: 'coworkers@code.com' },
@@ -82,6 +86,8 @@ export default function TeamPage() {
   const teamName = userData?.group.name ?? '팀 없음';
   const groupId = userData?.group.id;
   const { data: groupDetail } = useGroupDetail(groupId);
+  const taskListIds = groupDetail?.taskLists.map((list) => list.id) ?? [];
+  const taskQueries = useAllTaskListTasks(groupId, taskListIds);
 
   return (
     <div className="py-6">
@@ -117,9 +123,16 @@ export default function TeamPage() {
           </Modal>
         </header>
 
-        {groupDetail?.taskLists.map((list) => (
-          <TasksItem key={list.id} completed={1} total={3} tasksTitle={list.name} />
-        ))}
+        {groupDetail?.taskLists.map((list, index) => {
+          const taskQuery = taskQueries[index];
+          const tasks = taskQuery?.data ?? [];
+          const total = tasks.length;
+          const completed = tasks.filter((task) => task.doneAt !== null).length;
+
+          return (
+            <TasksItem key={list.id} completed={completed} total={total} tasksTitle={list.name} />
+          );
+        })}
       </section>
 
       <section className={sectionStyle}>

--- a/src/app/(pages)/(main)/[teamid]/page.tsx
+++ b/src/app/(pages)/(main)/[teamid]/page.tsx
@@ -93,6 +93,12 @@ export default function TeamPage() {
   const taskListIds = groupDetail?.taskLists.map((list) => list.id) ?? [];
   const taskQueries = useAllTaskListTasks(groupId, taskListIds, futureDate ?? '');
 
+  const todayDate = new Date().toISOString().split('T')[0];
+  const todayTaskQueries = useAllTaskListTasks(groupId, taskListIds, todayDate);
+  const todayTasks = todayTaskQueries.flatMap((query) => query?.data ?? []);
+  const totalTodayTasks = todayTasks.length;
+  const completedTodayTasks = todayTasks.filter((task) => task.doneAt !== null).length;
+
   return (
     <div className="py-6">
       <TeamHeader title={teamName} showGear={isClient && isAdmin} />
@@ -147,7 +153,7 @@ export default function TeamPage() {
           </div>
         </header>
 
-        <Report />
+        <Report total={totalTodayTasks} completed={completedTodayTasks} />
       </section>
 
       <section className={sectionStyle}>

--- a/src/components/myhistory/MyHistoryByDate.tsx
+++ b/src/components/myhistory/MyHistoryByDate.tsx
@@ -1,6 +1,6 @@
 import MyHistoryItem from '@/components/myhistory/MyHistoryItem';
 import { MyHistoryByDateProps } from '@/types/myhistorytypes';
-import getKoreanDateString from '@/utils/date';
+import { getKoreanDateString } from '@/utils/date';
 
 export default function TaskHistoryByDate({ date, history }: MyHistoryByDateProps) {
   return (

--- a/src/components/teampage/Report.tsx
+++ b/src/components/teampage/Report.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
-import ReportProgress from '@/components/teampage/ReportProgress';
-import { ProgressProp, UrgentTaskProps } from '@/types/teampagetypes';
 import Alert from '@/assets/icons/Alert';
+import ReportProgress from '@/components/teampage/ReportProgress';
+import { ProgressProp, UrgentTaskProps, ReportProps } from '@/types/teampagetypes';
 
 const taskReportBoxStyle = 'flex h-20 w-full items-end justify-between bg-bg100 p-4 rounded-xl';
 const taskReportTextBoxStyle = 'flex flex-col items-start justify-center gap-1 ';
@@ -30,35 +30,35 @@ function LeftSide({ percentage }: ProgressProp) {
   );
 }
 
-function TodayTasks() {
+function TodayTasks({ total }: { total: number }) {
   return (
     <div className={taskReportBoxStyle}>
       <div className={taskReportTextBoxStyle}>
         <h3 className={taskReportLabelStyle}>오늘의 할 일</h3>
-        <p className={taskReportNumberStyle}>20개</p>
+        <p className={taskReportNumberStyle}>{total}개</p>
       </div>
       <Image src="/icons/head.svg" alt="오늘의 할 일" width={40} height={40} />
     </div>
   );
 }
 
-function TodayCompletedTasks() {
+function TodayCompletedTasks({ completed }: { completed: number }) {
   return (
     <div className={taskReportBoxStyle}>
       <div className={taskReportTextBoxStyle}>
         <h3 className={taskReportLabelStyle}>한 일</h3>
-        <p className={taskReportNumberStyle}>5</p>
+        <p className={taskReportNumberStyle}>{completed}</p>
       </div>
       <Image src="/icons/sign_done.svg" alt="한 일" width={40} height={40} />
     </div>
   );
 }
 
-function TaskReportColumn() {
+function TaskReportColumn({ total, completed }: ReportProps) {
   return (
     <div className="flex w-full flex-col gap-4">
-      <TodayTasks />
-      <TodayCompletedTasks />
+      <TodayTasks total={total} />
+      <TodayCompletedTasks completed={completed} />
     </div>
   );
 }
@@ -84,9 +84,7 @@ function UrgentTaskForMobile({ title, dueDate }: UrgentTaskProps) {
         <Alert className="text-white" />
         <div className="flex flex-col items-center justify-center">
           <p className="text-xs-regular text-tertiary whitespace-nowrap">마감 임박</p>
-          <p className="text-lg-medium h-fit w-fit rounded-l-full whitespace-nowrap">
-            {dueDate}
-          </p>
+          <p className="text-lg-medium h-fit w-fit rounded-l-full whitespace-nowrap">{dueDate}</p>
         </div>
       </div>
       <div className="flex h-full w-full items-center">
@@ -105,7 +103,7 @@ function UrgentTasksReportColumn() {
   );
 }
 
-export default function Report() {
+export default function Report({ total, completed }: ReportProps) {
   return (
     <div className="relative w-full">
       <div className="bg-bg200 grid grid-cols-2 gap-4 rounded-xl px-2 py-2 sm:grid-cols-3 sm:px-6">
@@ -114,7 +112,7 @@ export default function Report() {
           <UrgentTasksReportColumn />
         </div>
         <div className="flex justify-end">
-          <TaskReportColumn />
+          <TaskReportColumn total={total} completed={completed} />
         </div>
       </div>
       <div className="mt-4 flex flex-col items-center justify-start gap-4 sm:hidden">

--- a/src/components/teampage/Report.tsx
+++ b/src/components/teampage/Report.tsx
@@ -104,10 +104,12 @@ function UrgentTasksReportColumn() {
 }
 
 export default function Report({ total, completed }: ReportProps) {
+  const percentage = total === 0 ? 0 : Math.round((completed / total) * 100);
+
   return (
     <div className="relative w-full">
       <div className="bg-bg200 grid grid-cols-2 gap-4 rounded-xl px-2 py-2 sm:grid-cols-3 sm:px-6">
-        <LeftSide percentage={25} />
+        <LeftSide percentage={percentage} />
         <div className="hidden justify-center sm:flex">
           <UrgentTasksReportColumn />
         </div>

--- a/src/components/teampage/TeamHeader.tsx
+++ b/src/components/teampage/TeamHeader.tsx
@@ -8,7 +8,7 @@ import { useParams, useRouter } from 'next/navigation';
 export default function TeamHeader({ title, showGear }: TeamHeaderProp) {
   const router = useRouter();
   const params = useParams();
-  const teamid = params.teamId as string;
+  const teamid = params.teamid as string;
 
   return (
     <div

--- a/src/hooks/useGroupDetail.ts
+++ b/src/hooks/useGroupDetail.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getGroupDetail } from '@/api/group.api';
+import { Group } from '@/types/grouptypes';
+
+export const useGroupDetail = (groupId: number | undefined) => {
+  return useQuery<Group>({
+    queryKey: ['groupDetail', groupId],
+    queryFn: () => getGroupDetail(groupId!),
+    enabled: !!groupId,
+  });
+};

--- a/src/hooks/useGroupPageInfo.ts
+++ b/src/hooks/useGroupPageInfo.ts
@@ -2,9 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import { getGroupPageInfo } from '@/api/user.api';
 import { GroupPageInfo } from '@/types/teampagetypes';
 
-export const useGroupPageInfo = () => {
+export const useGroupPageInfo = (groupId: string) => {
   return useQuery<GroupPageInfo>({
-    queryKey: ['groupPageInfo'],
-    queryFn: getGroupPageInfo,
+    queryKey: ['groupPageInfo', groupId],
+    queryFn: () => getGroupPageInfo(groupId),
+    enabled: !!groupId,
   });
 };

--- a/src/hooks/useGroupPageInfo.ts
+++ b/src/hooks/useGroupPageInfo.ts
@@ -1,6 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueries } from '@tanstack/react-query';
 import { getGroupPageInfo } from '@/api/user.api';
-import { GroupPageInfo } from '@/types/teampagetypes';
+import { getTasksByTaskList } from '@/api/tasklist.api';
+import { GroupPageInfo, TaskInfo } from '@/types/teampagetypes';
+import { getFutureDateString } from '@/utils/date';
 
 export const useGroupPageInfo = (groupId: string) => {
   return useQuery<GroupPageInfo>({
@@ -8,4 +10,18 @@ export const useGroupPageInfo = (groupId: string) => {
     queryFn: () => getGroupPageInfo(groupId),
     enabled: !!groupId,
   });
+};
+
+export const useAllTaskListTasks = (groupId: number | undefined, taskListIds: number[]) => {
+  const distantFuture = getFutureDateString(100);
+
+  return useQueries({
+    queries: taskListIds.map((taskListId) => ({
+      queryKey: ['tasks', taskListId, distantFuture],
+      queryFn: () => getTasksByTaskList(groupId!, taskListId, distantFuture),
+      enabled: !!groupId && !!taskListId,
+    })),
+  }) as {
+    data: TaskInfo[] | undefined;
+  }[];
 };

--- a/src/hooks/useGroupPageInfo.ts
+++ b/src/hooks/useGroupPageInfo.ts
@@ -2,7 +2,6 @@ import { useQuery, useQueries } from '@tanstack/react-query';
 import { getGroupPageInfo } from '@/api/user.api';
 import { getTasksByTaskList } from '@/api/tasklist.api';
 import { GroupPageInfo, TaskInfo } from '@/types/teampagetypes';
-import { getFutureDateString } from '@/utils/date';
 
 export const useGroupPageInfo = (groupId: string) => {
   return useQuery<GroupPageInfo>({
@@ -12,13 +11,15 @@ export const useGroupPageInfo = (groupId: string) => {
   });
 };
 
-export const useAllTaskListTasks = (groupId: number | undefined, taskListIds: number[]) => {
-  const distantFuture = getFutureDateString(100);
-
+export const useAllTaskListTasks = (
+  groupId: number | undefined,
+  taskListIds: number[],
+  date: string
+) => {
   return useQueries({
     queries: taskListIds.map((taskListId) => ({
-      queryKey: ['tasks', taskListId, distantFuture],
-      queryFn: () => getTasksByTaskList(groupId!, taskListId, distantFuture),
+      queryKey: ['tasks', taskListId, date],
+      queryFn: () => getTasksByTaskList(groupId!, taskListId, date),
       enabled: !!groupId && !!taskListId,
     })),
   }) as {

--- a/src/types/tasklisttypes.ts
+++ b/src/types/tasklisttypes.ts
@@ -1,3 +1,5 @@
+import { Task } from '@/types/tasktypes';
+
 export interface TaskList {
   id: number;
   name: string;
@@ -5,5 +7,5 @@ export interface TaskList {
   displayIndex: number;
   createdAt: string;
   updatedAt: string;
-  tasks: string[];
+  tasks: Task[];
 }

--- a/src/types/teampagetypes.ts
+++ b/src/types/teampagetypes.ts
@@ -17,5 +17,5 @@ export interface UrgentTaskProps {
 }
 
 export type GroupPageInfo = Pick<Memberships, 'role'> & {
-  group: Pick<Memberships['group'], 'name'>;
+  group: Pick<Memberships['group'], 'id' | 'name'>;
 };

--- a/src/types/teampagetypes.ts
+++ b/src/types/teampagetypes.ts
@@ -22,3 +22,8 @@ export type GroupPageInfo = Pick<Memberships, 'role'> & {
 };
 
 export type TaskInfo = Pick<Task, 'id' | 'name' | 'description' | 'date' | 'doneAt'>;
+
+export interface ReportProps {
+  total: number;
+  completed: number;
+}

--- a/src/types/teampagetypes.ts
+++ b/src/types/teampagetypes.ts
@@ -1,4 +1,5 @@
 import { Memberships } from '@/types/usertypes';
+import { Task } from './tasktypes';
 
 export interface MemberProps {
   profileUrl?: string;
@@ -19,3 +20,5 @@ export interface UrgentTaskProps {
 export type GroupPageInfo = Pick<Memberships, 'role'> & {
   group: Pick<Memberships['group'], 'id' | 'name'>;
 };
+
+export type TaskInfo = Pick<Task, 'id' | 'name' | 'description' | 'date' | 'doneAt'>;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,7 +1,16 @@
-export default function getKoreanDateString(dateString: string): string {
+export function getKoreanDateString(dateString: string): string {
   const date = new Date(dateString);
   const year = date.getFullYear();
   const month = date.getMonth() + 1;
   const day = date.getDate();
   return `${year}년 ${month}월 ${day}일`;
 }
+
+export const getFutureDateString = (yearsAhead: number): string => {
+  const now = new Date();
+  now.setFullYear(now.getFullYear() + yearsAhead);
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};


### PR DESCRIPTION
## ✨ 작업 내용

- 현재 팀페이지에 맞는 팀이름 표시
- 팀 수정 연결 확인
- 새로운 목록 추가 구현
- 할일목록의 progress badge에 API 연결
- 리포트 섹션의 오늘의 진행상황, 오늘의 할 일, 한 일과 API 연결

## 🔍 관련 이슈

- 관련된 이슈 번호가 있다면 적어주세요. (`ex. #12`)

## 📝 변경사항

- 어떤 코드나 파일이 변경되었는지 요약해주세요.

## 📌 참고 사항

- 코드 리뷰 시 알아두면 좋을 사항이나 스크린샷이 있다면 여기에 작성해주세요.
