### PR TITLE
[Feat]

### DIFF
--- a/src/api/group.api.ts
+++ b/src/api/group.api.ts
@@ -5,3 +5,22 @@ export const getGroupDetail = async (groupId: number): Promise<Group> => {
   const response = await axiosInstance.get(`/groups/${groupId}`);
   return response.data;
 };
+
+export const getInvitationToken = async (groupId: number): Promise<string> => {
+  const response = await axiosInstance.get(`/groups/${groupId}/invitation`);
+  return typeof response.data === 'string' ? response.data : '';
+};
+
+export const acceptGroupInvitation = async ({
+  email,
+  token,
+}: {
+  email: string;
+  token: string;
+}): Promise<{ groupId: number }> => {
+  const response = await axiosInstance.post('/groups/accept-invitation', {
+    userEmail: email,
+    token,
+  });
+  return response.data;
+};

--- a/src/api/tasklist.api.ts
+++ b/src/api/tasklist.api.ts
@@ -18,3 +18,14 @@ export const getTasksByTaskList = async (
   });
   return response.data;
 };
+
+export const getTaskDetail = async (
+  groupId: number,
+  taskListId: number,
+  taskId: number
+): Promise<Task> => {
+  const response = await axiosInstance.get(
+    `/groups/${groupId}/task-lists/${taskListId}/tasks/${taskId}`
+  );
+  return response.data;
+};

--- a/src/api/user.api.ts
+++ b/src/api/user.api.ts
@@ -1,10 +1,10 @@
 import axiosInstance from '@/api/axiosInstance';
 import { GroupPageInfo } from '@/types/teampagetypes';
-import { Memberships } from '@/types/usertypes';
+import { Membership, User } from '@/types/usertypes';
 
 export const getGroupPageInfo = async (groupId: string): Promise<GroupPageInfo> => {
   const res = await axiosInstance.get(`/user/memberships`);
-  const memberships: Memberships[] = res.data;
+  const memberships: Membership[] = res.data;
 
   const matched = memberships.find((m) => String(m.group.id) === groupId);
   if (!matched) throw new Error('No matching group found');
@@ -16,4 +16,9 @@ export const getGroupPageInfo = async (groupId: string): Promise<GroupPageInfo> 
       name: matched.group.name,
     },
   };
+};
+
+export const fetchUser = async (): Promise<User> => {
+  const { data } = await axiosInstance.get('/user');
+  return data;
 };

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '@/api/axiosInstance';
-import { Memberships } from '@/types/usertypes';
+import { Membership } from '@/types/usertypes';
 
 export interface Team {
   id: string;
@@ -18,7 +18,7 @@ export interface RawUserResponse {
   id?: number;
   nickname: string;
   image: string | null;
-  memberships: Memberships[];
+  memberships: Membership[];
 }
 
 export const fetchUser = async () => {

--- a/src/app/(pages)/(auth)/invite/page.tsx
+++ b/src/app/(pages)/(auth)/invite/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useMemo, useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { toast } from 'react-toastify';
+import InviteAuthForm from '@/components/invite/InviteAuthForm';
+import InviteAcceptScreen from '@/components/invite/InviteAcceptScreen';
+import { useInvitedUserInfo } from '@/hooks/useInvitePageInfo';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+export default function InvitePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [mode, setMode] = useState<'checking' | 'accept' | 'auth'>('checking');
+  const token = useMemo(() => searchParams.get('token'), [searchParams]);
+  const accessToken = useAuthStore.getState().accessToken;
+
+  useInvitedUserInfo();
+
+  useEffect(() => {
+    if (!token) {
+      toast.error('유효하지 않은 초대 링크입니다.');
+      router.replace('/');
+      return;
+    }
+
+    if (accessToken) {
+      setMode('accept');
+    } else {
+      setMode('auth');
+    }
+  }, [token, accessToken, router]);
+
+  if (!token) {
+    toast.error('유효하지 않은 초대 링크입니다.');
+    router.replace('/');
+    return;
+  }
+
+  if (mode === 'checking') {
+    return <div className="p-8 text-center">초대 정보를 불러오는 중...</div>;
+  }
+
+  if (mode === 'auth') {
+    return <InviteAuthForm token={token} />;
+  }
+
+  if (mode === 'accept') {
+    return <InviteAcceptScreen token={token} />;
+  }
+
+  return null;
+}

--- a/src/app/(pages)/(main)/[teamid]/page.tsx
+++ b/src/app/(pages)/(main)/[teamid]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useParams } from 'next/navigation';
 import { toast } from 'react-toastify';
+import { useQueryClient } from '@tanstack/react-query';
 import { TextInput } from '@/components/common/Inputs';
 import { TasksItem } from '@/components/teampage/TaskElements';
 import TeamHeader from '@/components/teampage/TeamHeader';
@@ -33,6 +34,7 @@ export default function TeamPage() {
   const sectionHeaderH2Style = 'text-lg-medium font-semibold';
   const sectionHeaderPSTyle = 'text-lg-regular text-gray500';
   const sectionHeaderButtonStyle = 'text-md-regular text-primary';
+  const queryClient = useQueryClient();
 
   const [newListName, setNewListName] = useState('');
   const [selectedMember, setSelectedMember] = useState<{ name: string; email: string } | null>(
@@ -53,6 +55,8 @@ export default function TeamPage() {
         groupId: groupId,
         name: newListName.trim(),
       });
+
+      await queryClient.invalidateQueries({ queryKey: ['groupDetail', groupId] });
 
       toast.success('새로운 목록이 생성되었습니다.');
       close();

--- a/src/app/(pages)/(main)/[teamid]/page.tsx
+++ b/src/app/(pages)/(main)/[teamid]/page.tsx
@@ -19,14 +19,6 @@ import { useModalGroup } from '@/hooks/useModalGroup';
 import { NewestTaskProps } from '@/types/teampagetypes';
 import { getFutureDateString, formatElapsedTime } from '@/utils/date';
 
-const mockMembers = [
-  { name: '우지은', email: 'coworkers@code.com' },
-  { name: '김하늘', email: 'skyblue@example.com' },
-  { name: '박서준', email: 'seojoon@example.com' },
-  { name: '이수민', email: 'soomin@example.com' },
-  { name: '정해인', email: 'haein@example.com' },
-];
-
 export default function TeamPage() {
   const sectionStyle = 'w-full py-6 flex flex-col items-center justify-start gap-4';
   const sectionHeaderStyle = 'flex w-full items-center justify-between';
@@ -37,9 +29,11 @@ export default function TeamPage() {
   const queryClient = useQueryClient();
 
   const [newListName, setNewListName] = useState('');
-  const [selectedMember, setSelectedMember] = useState<{ name: string; email: string } | null>(
-    null
-  );
+  const [selectedMember, setSelectedMember] = useState<{
+    name: string;
+    email: string;
+    profileUrl?: string | null;
+  } | null>(null);
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => setIsClient(true), []);
@@ -89,7 +83,11 @@ export default function TeamPage() {
     toast.success('복사되었습니다.');
   };
 
-  const handleOpenProfile = (member: { name: string; email: string }) => {
+  const handleOpenProfile = (member: {
+    name: string;
+    email: string;
+    profileUrl?: string | null;
+  }) => {
     setSelectedMember(member);
     open('memberProfile');
   };
@@ -228,7 +226,7 @@ export default function TeamPage() {
         <header className={sectionHeaderStyle}>
           <div className={sectionHeaderTitleStyle}>
             <h2 className={sectionHeaderH2Style}>멤버</h2>
-            <p className={sectionHeaderPSTyle}>(8명)</p>
+            <p className={sectionHeaderPSTyle}>({groupDetail?.members.length ?? 0}명)</p>
           </div>
           <div>
             {isClient && isAdmin && (
@@ -251,12 +249,19 @@ export default function TeamPage() {
           </div>
         </header>
         <div className="grid-rows-auto grid w-full grid-cols-[1fr_1fr] gap-4 sm:grid-cols-[1fr_1fr_1fr]">
-          {mockMembers.map((member) => (
+          {groupDetail?.members.map((member) => (
             <Member
-              key={member.email}
-              name={member.name}
-              email={member.email}
-              onClick={() => handleOpenProfile(member)}
+              key={member.userId}
+              name={member.userName}
+              email={member.userEmail}
+              profileUrl={member.userImage}
+              onClick={() =>
+                handleOpenProfile({
+                  name: member.userName,
+                  email: member.userEmail,
+                  profileUrl: member.userImage,
+                })
+              }
             />
           ))}
         </div>
@@ -269,7 +274,7 @@ export default function TeamPage() {
           onSubmit={handleCopyMemberEmail}
         >
           <div className="flex flex-col items-center gap-6">
-            <Profile width={52} />
+            <Profile width={52} profileUrl={selectedMember?.profileUrl} />
             <div className="flex flex-col items-center gap-2 text-center">
               <p className="text-md-medium">{selectedMember?.name}</p>
               <p className="text-xs-regular">{selectedMember?.email}</p>

--- a/src/app/(pages)/(main)/[teamid]/page.tsx
+++ b/src/app/(pages)/(main)/[teamid]/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import { useQueryClient } from '@tanstack/react-query';
 import { TextInput } from '@/components/common/Inputs';
-import { TasksItem } from '@/components/teampage/TaskElements';
+import { TaskListsItem } from '@/components/teampage/TaskElements';
 import TeamHeader from '@/components/teampage/TeamHeader';
 import Report from '@/components/teampage/Report';
 import Member from '@/components/common/Member';
@@ -27,6 +27,7 @@ export default function TeamPage() {
   const sectionHeaderPSTyle = 'text-lg-regular text-gray500';
   const sectionHeaderButtonStyle = 'text-md-regular text-primary';
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   const [newListName, setNewListName] = useState('');
   const [selectedMember, setSelectedMember] = useState<{
@@ -207,7 +208,15 @@ export default function TeamPage() {
           if (!futureDate) return null;
 
           return (
-            <TasksItem key={list.id} completed={completed} total={total} tasksTitle={list.name} />
+            <TaskListsItem
+              key={list.id}
+              completed={completed}
+              total={total}
+              tasksTitle={list.name}
+              onClick={() => {
+                router.push(`/${groupId}/tasklist?listId=${list.id}`);
+              }}
+            />
           );
         })}
       </section>

--- a/src/app/(pages)/(main)/[teamid]/page.tsx
+++ b/src/app/(pages)/(main)/[teamid]/page.tsx
@@ -10,6 +10,7 @@ import Report from '@/components/teampage/Report';
 import Member from '@/components/common/Member';
 import Modal from '@/components/common/Modal';
 import { Profile } from '@/components/common/Profiles';
+import { getInvitationToken } from '@/api/group.api';
 import { createTaskList, getTaskDetail } from '@/api/tasklist.api';
 import { useGroupDetail } from '@/hooks/useGroupDetail';
 import { useGroupPageInfo, useAllTaskListTasks } from '@/hooks/useGroupPageInfo';
@@ -63,8 +64,19 @@ export default function TeamPage() {
   };
 
   const handleCopyPageLink = async () => {
-    await navigator.clipboard.writeText('https://your-invite-link.com');
-    toast.success('복사되었습니다.');
+    if (!groupId) {
+      toast.error('그룹 정보를 불러오지 못했습니다.');
+      return;
+    }
+    try {
+      const token = await getInvitationToken(groupId);
+      const inviteUrl = `${window.location.origin}/invite?token=${token}`;
+      await navigator.clipboard.writeText(inviteUrl);
+      toast.success('초대 링크가 복사되었습니다.');
+    } catch (error) {
+      console.error(error);
+      toast.error('초대 링크 생성에 실패했습니다.');
+    }
   };
 
   const handleCopyMemberEmail = async () => {

--- a/src/components/common/Inputs.tsx
+++ b/src/components/common/Inputs.tsx
@@ -22,7 +22,7 @@ const BaseInputStyle =
 const EmailInputStyle = `${BaseInputStyle} focus:outline-none placeholder:text-gray500 sm:text-4 sm:text-lg-regular text-md-regular text-3.5 text-gray100`;
 
 const PasswordInputStyle =
-  'w-full h-full focus:outline-none sm:text-4 sm:text-lg-regular text-md-regular text-3.5 placeholder:text-gray500';
+  'w-full focus:outline-none sm:text-4 sm:text-lg-regular text-md-regular text-3.5 placeholder:text-gray500';
 
 const InputStyle =
   'w-full sm:h-12 h-11 bg-bg200 border border-gray100/10 rounded-xl px-4 focus:outline-none focus:border-primary hover:border-primary-hover sm:text-4 sm:text-lg-regular text-md-regular text-3.5 placeholder:text-gray500';

--- a/src/components/invite/InviteAcceptScreen.tsx
+++ b/src/components/invite/InviteAcceptScreen.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
+import { acceptGroupInvitation } from '@/api/group.api';
+import { useInvitedUserInfo } from '@/hooks/useInvitePageInfo';
+import { useUserStore } from '@/stores/useUserStore';
+import extractGroupIdFromToken from '@/utils/inviteTokenDecoder';
+
+export default function InviteAcceptScreen({ token }: { token: string }) {
+  const router = useRouter();
+  const { email, isLoading } = useInvitedUserInfo();
+  const tokenGroupId = extractGroupIdFromToken(token);
+  const teams = useUserStore((state) => state.teams);
+  const alreadyMember = tokenGroupId && teams.some((team) => String(team.id) === tokenGroupId);
+
+  const [error, setError] = useState<string | null>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && !email) {
+      toast.error('이메일 정보를 가져오지 못했습니다.');
+      setError('이메일 정보를 가져오지 못했습니다.');
+    }
+  }, [isLoading, email]);
+
+  useEffect(() => {
+    if (alreadyMember) {
+      toast.info('이미 가입된 그룹입니다.');
+      router.replace(`/${tokenGroupId}`);
+      return;
+    }
+
+    if (!isLoading && email) {
+      setShowConfirm(true);
+    }
+  }, [alreadyMember, email, isLoading, router, tokenGroupId]);
+
+  const handleAccept = async () => {
+    try {
+      const { groupId } = await acceptGroupInvitation({ email: email!, token });
+      toast.success('초대를 수락했습니다.');
+      router.replace(`/${groupId}`);
+    } catch (error) {
+      console.error(error);
+      toast.error('초대 수락에 실패했습니다.');
+      router.replace('/');
+    }
+  };
+
+  if (isLoading) {
+    return <div className="p-8 text-center">초대 정보를 불러오는 중...</div>;
+  }
+
+  if (error) {
+    return <div className="p-8 text-center text-red-500">{error}</div>;
+  }
+
+  if (!showConfirm) return null;
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-8 text-center">
+      <p className="text-lg">초대를 수락하시겠습니까?</p>
+      <button
+        onClick={handleAccept}
+        className="bg-primary hover:bg-primary-hover rounded px-6 py-2 text-white transition"
+      >
+        초대 수락
+      </button>
+    </div>
+  );
+}

--- a/src/components/invite/InviteAuthForm.tsx
+++ b/src/components/invite/InviteAuthForm.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
+import { signup, login } from '@/api/auth';
+import { EmailInput, PasswordInput, TextInput } from '@/components/common/Inputs';
+import Button from '@/components/common/Button/Button';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+export default function InviteAuthForm({ token }: { token: string }) {
+  const router = useRouter();
+  const [mode, setMode] = useState<'login' | 'signup'>('signup');
+  const [form, setForm] = useState({
+    email: '',
+    nickname: '',
+    password: '',
+    passwordConfirmation: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSignup = async () => {
+    if (!form.email || !form.nickname || !form.password || !form.passwordConfirmation) {
+      toast.error('모든 항목을 입력해주세요.');
+      return;
+    }
+    if (form.password !== form.passwordConfirmation) {
+      toast.error('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+
+    try {
+      await signup(form);
+      const { accessToken } = await login({ email: form.email, password: form.password });
+
+      useAuthStore.getState().setAccessToken(accessToken);
+      toast.success('회원가입 성공!');
+      router.replace(`/invite?token=${token}`);
+    } catch (e: unknown) {
+      if (e && typeof e === 'object' && 'response' in e) {
+        const err = e as { response?: { data?: { message?: string } } };
+        toast.error(err.response?.data?.message || '로그인 실패');
+      } else {
+        toast.error('로그인 실패');
+      }
+    }
+  };
+
+  const handleLogin = async () => {
+    try {
+      const { accessToken } = await login({
+        email: form.email,
+        password: form.password,
+      });
+      useAuthStore.getState().setAccessToken(accessToken);
+      toast.success('로그인 성공!');
+      router.replace(`/invite?token=${token}`);
+    } catch (e: unknown) {
+      if (e && typeof e === 'object' && 'response' in e) {
+        const err = e as { response?: { data?: { message?: string } } };
+        toast.error(err.response?.data?.message || '회원가입 실패');
+      } else {
+        toast.error('회원가입 실패');
+      }
+    }
+  };
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col gap-6 p-8">
+      <h1 className="text-xl-bold text-center">
+        초대 수락을 위해 {mode === 'signup' ? '회원가입' : '로그인'} 해주세요
+      </h1>
+
+      {mode === 'signup' && (
+        <TextInput
+          name="nickname"
+          placeholder="닉네임"
+          value={form.nickname}
+          onChange={handleChange}
+        />
+      )}
+      <EmailInput name="email" placeholder="이메일" value={form.email} onChange={handleChange} />
+      <PasswordInput
+        name="password"
+        placeholder="비밀번호"
+        value={form.password}
+        onChange={handleChange}
+      />
+      {mode === 'signup' && (
+        <PasswordInput
+          name="passwordConfirmation"
+          placeholder="비밀번호 확인"
+          value={form.passwordConfirmation}
+          onChange={handleChange}
+        />
+      )}
+
+      <Button fullWidth variant="primary" onClick={mode === 'signup' ? handleSignup : handleLogin}>
+        {mode === 'signup' ? '회원가입 후 계속하기' : '로그인 후 계속하기'}
+      </Button>
+
+      <button
+        className="text-gray400 hover:text-primary text-center text-sm underline"
+        onClick={() => setMode(mode === 'signup' ? 'login' : 'signup')}
+      >
+        {mode === 'signup'
+          ? '이미 계정이 있으신가요? 로그인하기'
+          : '계정이 없으신가요? 회원가입하기'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/teampage/Report.tsx
+++ b/src/components/teampage/Report.tsx
@@ -1,7 +1,11 @@
 import Image from 'next/image';
 import Alert from '@/assets/icons/Alert';
 import ReportProgress from '@/components/teampage/ReportProgress';
-import { ProgressProp, UrgentTaskProps, ReportProps } from '@/types/teampagetypes';
+import {
+  ProgressProp,
+  NewestTaskProps as NewestTaskProps,
+  ReportProps,
+} from '@/types/teampagetypes';
 
 const taskReportBoxStyle = 'flex h-20 w-full items-end justify-between bg-bg100 p-4 rounded-xl';
 const taskReportTextBoxStyle = 'flex flex-col items-start justify-center gap-1 ';
@@ -63,28 +67,30 @@ function TaskReportColumn({ total, completed }: ReportProps) {
   );
 }
 
-function UrgentTask({ title, dueDate }: UrgentTaskProps) {
+function NewestTask({ title, elapsedTime: elapsedTime }: NewestTaskProps) {
   return (
     <div
       className={`${taskReportBoxStyle} border-danger from-danger via-bg200 to-bg100 bg-gradient-to-r via-[12px] to-50%`}
     >
       <div className={taskReportTextBoxStyle}>
-        <h3 className="text-xs-medium text-pink">마감임박</h3>
-        <p className={taskReportLabelStyle}>{dueDate}</p>
+        <h3 className="text-xs-medium text-pink">NEWEST</h3>
+        <p className={taskReportLabelStyle}>{elapsedTime}</p>
         <p className={`${taskReportNumberStyle} text-md-medium break-word line-clamp-1`}>{title}</p>
       </div>
     </div>
   );
 }
 
-function UrgentTaskForMobile({ title, dueDate }: UrgentTaskProps) {
+function NewestTaskForMobile({ title, elapsedTime: elapsedTime }: NewestTaskProps) {
   return (
     <div className="bg-bg200 right-[28%] flex h-14 w-full items-center justify-start gap-4 rounded-xl pr-2">
       <div className="from-danger to-bg200 flex h-full w-70 items-center justify-start gap-2 rounded-l-xl bg-gradient-to-r px-2">
         <Alert className="text-white" />
         <div className="flex flex-col items-center justify-center">
-          <p className="text-xs-regular text-tertiary whitespace-nowrap">마감 임박</p>
-          <p className="text-lg-medium h-fit w-fit rounded-l-full whitespace-nowrap">{dueDate}</p>
+          <p className="text-xs-regular text-tertiary test-left w-full whitespace-nowrap">NEWEST</p>
+          <p className="text-lg-medium h-fit w-fit rounded-l-full whitespace-nowrap">
+            {elapsedTime}
+          </p>
         </div>
       </div>
       <div className="flex h-full w-full items-center">
@@ -94,33 +100,43 @@ function UrgentTaskForMobile({ title, dueDate }: UrgentTaskProps) {
   );
 }
 
-function UrgentTasksReportColumn() {
+function NewestTasksReportColumn({ tasks }: { tasks: NewestTaskProps[] }) {
   return (
     <div className="flex w-full flex-col gap-4">
-      <UrgentTask title="주주명부 작성하기" dueDate="15시간 1분 9초" />
-      <UrgentTask title="법인 사무실 임대차 계약 체결하기" dueDate="39시간 33분 56초" />
+      {tasks.map((task, index) => (
+        <NewestTask key={index} title={task.title} elapsedTime={task.elapsedTime} />
+      ))}
     </div>
   );
 }
 
-export default function Report({ total, completed }: ReportProps) {
+export default function Report({ total, completed, newestTasks: newestTasks = [] }: ReportProps) {
   const percentage = total === 0 ? 0 : Math.round((completed / total) * 100);
 
   return (
     <div className="relative w-full">
       <div className="bg-bg200 grid grid-cols-2 gap-4 rounded-xl px-2 py-2 sm:grid-cols-3 sm:px-6">
         <LeftSide percentage={percentage} />
-        <div className="hidden justify-center sm:flex">
-          <UrgentTasksReportColumn />
-        </div>
+        {newestTasks.length > 0 && newestTasks[0].elapsedTime !== '' && (
+          <div className="hidden justify-center sm:flex">
+            <NewestTasksReportColumn tasks={newestTasks} />
+          </div>
+        )}
         <div className="flex justify-end">
           <TaskReportColumn total={total} completed={completed} />
         </div>
       </div>
-      <div className="mt-4 flex flex-col items-center justify-start gap-4 sm:hidden">
-        <UrgentTaskForMobile title="주주명부 작성하기" dueDate="15시간 1분 9초" />
-        <UrgentTaskForMobile title="법인 사무실 임대차 계약 체결하기" dueDate="39시간 33분 56초" />
-      </div>
+      {newestTasks.length > 0 && newestTasks[0].elapsedTime !== '' && (
+        <div className="mt-4 flex flex-col items-center justify-start gap-4 sm:hidden">
+          {newestTasks.map((newestTask, index) => (
+            <NewestTaskForMobile
+              key={index}
+              title={newestTask.title}
+              elapsedTime={newestTask.elapsedTime}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/teampage/TaskElements.tsx
+++ b/src/components/teampage/TaskElements.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { trimColors } from '@/styles/trimColors';
-import { TaskListTapProps, ProgressBadgeProps, TasksItemProp } from '@/types/tasktypes';
+import { TaskListTapProps, ProgressBadgeProps, TaskListsItemProp } from '@/types/tasktypes';
 import stringToHash from '@/utils/stringToHash';
 import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
@@ -48,12 +48,15 @@ function getTrimColor(text: string): string {
   return trimColors[hash % trimColors.length];
 }
 
-export function TasksItem({ tasksTitle, completed, total }: TasksItemProp) {
+export function TaskListsItem({ tasksTitle, completed, total, onClick }: TaskListsItemProp) {
   const trimColor = getTrimColor(tasksTitle);
 
   return (
     <div className="bg-bg200 flex h-10 w-full items-center justify-between rounded-xl">
-      <button className="flex w-full items-center justify-start gap-3 overflow-hidden rounded-xl">
+      <button
+        className="flex w-full items-center justify-start gap-3 overflow-hidden rounded-xl"
+        onClick={onClick}
+      >
         <div className="h-10 w-3" style={{ backgroundColor: trimColor }} />
         <p className="text-md-medium w-full text-left">{tasksTitle}</p>
       </button>

--- a/src/hooks/useInvitePageInfo.ts
+++ b/src/hooks/useInvitePageInfo.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchUser } from '@/api/user';
+import { QUERY_KEYS } from '@/constants/queryKeys';
+import { useUserStore } from '@/stores/useUserStore';
+import { User } from '@/types/usertypes';
+
+export const useInvitedUserInfo = () => {
+  const setUserInfo = useUserStore((state) => state.setUserInfo);
+
+  const query = useQuery<User>({
+    queryKey: QUERY_KEYS.user.me,
+    queryFn: fetchUser,
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (query.data) {
+      const { nickname, image, memberships } = query.data;
+      const teams = memberships.map((membership) => ({
+        id: String(membership.group.id),
+        name: membership.group.name,
+        image: membership.group.image,
+      }));
+
+      setUserInfo({
+        nickname,
+        profileImage: image,
+        teams,
+      });
+    }
+  }, [query.data, setUserInfo]);
+
+  return {
+    ...query,
+    email: query.data?.email ?? null,
+    isLoggedIn: !!query.data?.id,
+  };
+};

--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -3,7 +3,7 @@ import { QUERY_KEYS } from '@/constants/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { useUserStore } from '@/stores/useUserStore';
 import { useEffect } from 'react';
-import type { Memberships } from '@/types/usertypes';
+import type { Membership } from '@/types/usertypes';
 
 export const useUserInfo = () => {
   const query = useQuery({
@@ -19,7 +19,7 @@ export const useUserInfo = () => {
       setUserInfo({
         nickname: query.data.nickname ?? '',
         profileImage: query.data.image ?? null,
-        teams: ((query.data.memberships as Memberships[]) ?? []).map((m) => ({
+        teams: ((query.data.memberships as Membership[]) ?? []).map((m) => ({
           id: String(m.group.id),
           name: m.group.name ?? '이름 없음',
           image: m.group.image ?? null,

--- a/src/types/profiletypes.tsx
+++ b/src/types/profiletypes.tsx
@@ -5,7 +5,7 @@ export interface BaseProfileProps {
 }
 
 export type ProfileProps = {
-  profileUrl?: string;
+  profileUrl?: string | null;
   width: number;
 };
 

--- a/src/types/tasktypes.ts
+++ b/src/types/tasktypes.ts
@@ -43,4 +43,7 @@ export interface Task {
       image: string;
     };
   } | null;
+  recurring: {
+    startDate: string;
+  };
 }

--- a/src/types/tasktypes.ts
+++ b/src/types/tasktypes.ts
@@ -13,10 +13,11 @@ export interface ProgressBadgeProps {
   totalTaskNumber: number;
 }
 
-export interface TasksItemProp {
+export interface TaskListsItemProp {
   tasksTitle: string;
   completed: number;
   total: number;
+  onClick?: () => void;
 }
 
 export interface Task {

--- a/src/types/teampagetypes.ts
+++ b/src/types/teampagetypes.ts
@@ -12,9 +12,9 @@ export type ProgressProp = {
   percentage: number;
 };
 
-export interface UrgentTaskProps {
+export interface NewestTaskProps {
   title: string;
-  dueDate: string;
+  elapsedTime: string;
 }
 
 export type GroupPageInfo = Pick<Memberships, 'role'> & {
@@ -26,4 +26,5 @@ export type TaskInfo = Pick<Task, 'id' | 'name' | 'description' | 'date' | 'done
 export interface ReportProps {
   total: number;
   completed: number;
+  newestTasks?: NewestTaskProps[];
 }

--- a/src/types/teampagetypes.ts
+++ b/src/types/teampagetypes.ts
@@ -1,4 +1,4 @@
-import { Memberships } from '@/types/usertypes';
+import { Membership } from '@/types/usertypes';
 import { Task } from './tasktypes';
 
 export interface MemberProps {
@@ -17,8 +17,8 @@ export interface NewestTaskProps {
   elapsedTime: string;
 }
 
-export type GroupPageInfo = Pick<Memberships, 'role'> & {
-  group: Pick<Memberships['group'], 'id' | 'name'>;
+export type GroupPageInfo = Pick<Membership, 'role'> & {
+  group: Pick<Membership['group'], 'id' | 'name'>;
 };
 
 export type TaskInfo = Pick<Task, 'id' | 'name' | 'description' | 'date' | 'doneAt'>;

--- a/src/types/teampagetypes.ts
+++ b/src/types/teampagetypes.ts
@@ -2,7 +2,7 @@ import { Membership } from '@/types/usertypes';
 import { Task } from './tasktypes';
 
 export interface MemberProps {
-  profileUrl?: string;
+  profileUrl?: string | null;
   name: string;
   email: string;
   onClick: () => void;

--- a/src/types/usertypes.ts
+++ b/src/types/usertypes.ts
@@ -1,27 +1,21 @@
 export interface User {
-  role: 'ADMIN' | 'MEMBER';
-  userId: number;
-  userName: string;
-  userEmail: string;
-  userImage: string | null;
-  groupId: number;
-  group: {
-    id: number;
-    name: string;
-    image: string | null;
-    teamId: string;
-    createdAt: string;
-    updatedAt: string;
-  };
+  id: number;
+  email: string;
+  nickname: string;
+  image: string | null;
+  teamId: string;
+  createdAt: string;
+  updatedAt: string;
+  memberships: Membership[];
 }
 
-export interface Memberships {
-  role: 'ADMIN' | 'MEMBER';
+export interface Membership {
   userId: number;
-  userName: string;
   userEmail: string;
+  userName: string;
   userImage: string | null;
   groupId: number;
+  role: 'ADMIN' | 'MEMBER';
   group: {
     id: number;
     name: string;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -14,3 +14,16 @@ export const getFutureDateString = (yearsAhead: number): string => {
   const day = String(now.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 };
+
+export const formatElapsedTime = (updatedAt: string): string => {
+  const updated = new Date(updatedAt);
+  const now = new Date();
+  const diffMs = now.getTime() - updated.getTime();
+
+  const seconds = Math.floor(diffMs / 1000);
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+
+  return `${hours}시간 ${minutes}분 ${secs}초`;
+};

--- a/src/utils/inviteTokenDecoder.ts
+++ b/src/utils/inviteTokenDecoder.ts
@@ -1,0 +1,9 @@
+export default function extractGroupIdFromToken(token: string): string | null {
+  try {
+    const payloadBase64 = token.split('.')[1];
+    const decodedPayload = JSON.parse(atob(payloadBase64));
+    return String(decodedPayload.groupId);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## ✨ 작업 내용

그룹페이지
- 할일목록 중 하나 클릭하면 할일목록 페이지로 이동
- 리포트섹션에 Newest 할일 표시(이전에 마감임박 할일 표시 예정이었으나 서버에 맞추어 변경)
- 새 할일목록 생성 시 새로고침 없이도 표시됨.
- 새로운 멤버 초대 기능 구현
- 멤버목록 요청/표시 구현

## 🔍 관련 이슈

- 관련된 이슈 번호가 있다면 적어주세요. (`ex. #12`)

## 📝 변경사항

- 어떤 코드나 파일이 변경되었는지 요약해주세요.

## 📌 참고 사항

- 할일목록 중 하나를 클릭해서 할일목록 페이지로 이동하는 URL에 쿼리스트링으로 해당 할일목록 정보(listId)가 포함돼있습니다.

![2025-05-20 16 09 12](https://github.com/user-attachments/assets/8f84e105-8841-4fb1-8ba7-fba83b212839)
