### PR TITLE
[Feat] Add pagination and real-time updates to group page

### DIFF
--- a/src/app/(pages)/(main)/[teamid]/TeamPage.tsx
+++ b/src/app/(pages)/(main)/[teamid]/TeamPage.tsx
@@ -213,6 +213,7 @@ export default function TeamPage() {
                 placeholder="목록 명을 입력해주세요."
                 value={newListName}
                 onChange={(e) => setNewListName(e.target.value)}
+                maxLength={10}
               />
             </div>
           </Modal>

--- a/src/app/(pages)/(main)/[teamid]/TeamPage.tsx
+++ b/src/app/(pages)/(main)/[teamid]/TeamPage.tsx
@@ -37,8 +37,12 @@ export default function TeamPage() {
     profileUrl?: string | null;
   } | null>(null);
   const [isClient, setIsClient] = useState(false);
+
   const [currentPage, setCurrentPage] = useState(1);
   const ITEMS_PER_PAGE = 5;
+
+  const [memberPage, setMemberPage] = useState(1);
+  const MEMBERS_PER_PAGE = 6;
 
   useEffect(() => setIsClient(true), []);
 
@@ -130,6 +134,14 @@ export default function TeamPage() {
   }, [groupDetail?.taskLists, currentPage]);
 
   const totalPages = Math.ceil((groupDetail?.taskLists?.length ?? 0) / ITEMS_PER_PAGE);
+
+  const paginatedMembers = useMemo(() => {
+    if (!groupDetail?.members) return [];
+    const startIndex = (memberPage - 1) * MEMBERS_PER_PAGE;
+    return groupDetail.members.slice(startIndex, startIndex + MEMBERS_PER_PAGE);
+  }, [groupDetail?.members, memberPage]);
+
+  const totalMemberPages = Math.ceil((groupDetail?.members?.length ?? 0) / MEMBERS_PER_PAGE);
 
   useEffect(() => {
     setFutureDate(getFutureDateString(100));
@@ -306,14 +318,14 @@ export default function TeamPage() {
           </div>
         </header>
         <div className="grid-rows-auto grid w-full grid-cols-[1fr_1fr] gap-4 sm:grid-cols-[1fr_1fr_1fr]">
-          {groupDetail?.members.map((member, index) => (
+          {paginatedMembers.map((member) => (
             <Member
               key={member.userId}
               name={member.userName}
               email={member.userEmail}
               profileUrl={member.userImage}
               userId={member.userId}
-              hideMenu={index === 0}
+              hideMenu={member.userId === groupDetail?.members[0]?.userId}
               onClick={() =>
                 handleOpenProfile({
                   name: member.userName,
@@ -324,6 +336,25 @@ export default function TeamPage() {
             />
           ))}
         </div>
+
+        {totalMemberPages > 1 && (
+          <div className="flex gap-2">
+            <button
+              onClick={() => setMemberPage((p) => Math.max(p - 1, 1))}
+              disabled={memberPage === 1}
+              className="border-gray100/10 hover:bg-bg200 disabled:hover:bg-bg300 rounded border px-2 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              ◀
+            </button>
+            <button
+              onClick={() => setMemberPage((p) => Math.min(p + 1, totalMemberPages))}
+              disabled={memberPage === totalMemberPages}
+              className="border-gray100/10 hover:bg-bg200 disabled:hover:bg-bg300 rounded border px-2 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              ▶
+            </button>
+          </div>
+        )}
 
         <Modal
           isOpen={isOpen('memberProfile')}

--- a/src/app/(pages)/(main)/[teamid]/TeamPage.tsx
+++ b/src/app/(pages)/(main)/[teamid]/TeamPage.tsx
@@ -37,6 +37,8 @@ export default function TeamPage() {
     profileUrl?: string | null;
   } | null>(null);
   const [isClient, setIsClient] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+  const ITEMS_PER_PAGE = 5;
 
   useEffect(() => setIsClient(true), []);
 
@@ -120,6 +122,14 @@ export default function TeamPage() {
   const todayTaskList = todayTasks.flatMap((entry) => entry.data ?? []);
   const totalTodayTasks = todayTaskList.length;
   const completedTodayTasks = todayTaskList.filter((task) => task.doneAt !== null).length;
+
+  const paginatedTaskLists = useMemo(() => {
+    if (!groupDetail?.taskLists) return [];
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    return groupDetail.taskLists.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+  }, [groupDetail?.taskLists, currentPage]);
+
+  const totalPages = Math.ceil((groupDetail?.taskLists?.length ?? 0) / ITEMS_PER_PAGE);
 
   useEffect(() => {
     setFutureDate(getFutureDateString(100));
@@ -218,7 +228,7 @@ export default function TeamPage() {
           </Modal>
         </header>
 
-        {groupDetail?.taskLists.map((list) => {
+        {paginatedTaskLists.map((list) => {
           const taskData = futureTasks.find((entry) => entry.taskListId === list.id)?.data ?? [];
           const total = taskData.length;
           const completed = taskData.filter((task) => task.doneAt !== null).length;
@@ -238,6 +248,25 @@ export default function TeamPage() {
             />
           );
         })}
+
+        {totalPages > 1 && (
+          <div className="flex gap-2">
+            <button
+              onClick={() => setCurrentPage((p) => Math.max(p - 1, 1))}
+              disabled={currentPage === 1}
+              className="border-gray100/10 hover:bg-bg200 disabled:hover:bg-bg300 rounded border px-2 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              ◀
+            </button>
+            <button
+              onClick={() => setCurrentPage((p) => Math.min(p + 1, totalPages))}
+              disabled={currentPage === totalPages}
+              className="border-gray100/10 hover:bg-bg200 disabled:hover:bg-bg300 rounded border px-2 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              ▶
+            </button>
+          </div>
+        )}
       </section>
 
       <section className={sectionStyle}>

--- a/src/app/(pages)/(main)/[teamid]/TeamPage.tsx
+++ b/src/app/(pages)/(main)/[teamid]/TeamPage.tsx
@@ -54,7 +54,6 @@ export default function TeamPage() {
 
       await queryClient.invalidateQueries({ queryKey: ['groupDetail', groupId] });
 
-      toast.success('새로운 목록이 생성되었습니다.');
       close();
       setNewListName('');
     } catch (error) {

--- a/src/components/common/ActionMenu.tsx
+++ b/src/components/common/ActionMenu.tsx
@@ -4,7 +4,12 @@ import { useRef, useState } from 'react';
 import useClickOutside from '@/hooks/useClickOutside';
 import { ActionMenuProps } from '@/types/actionmenutypes';
 
-export default function ActionMenu({ trigger, onDelete, menuPosition = 'right' }: ActionMenuProps) {
+export default function ActionMenu({
+  trigger,
+  onEdit,
+  onDelete,
+  menuPosition = 'right',
+}: ActionMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   useClickOutside(ref, () => setIsOpen(false));
@@ -21,12 +26,23 @@ export default function ActionMenu({ trigger, onDelete, menuPosition = 'right' }
             menuPosition === 'right' ? 'right-0' : 'left-0'
           }`}
         >
+          {onEdit && (
+            <div
+              onClick={() => {
+                onEdit();
+                setIsOpen(false);
+              }}
+              className="hover:bg-primary-hover h-10 w-full cursor-pointer px-4 py-[11.5px] text-left"
+            >
+              수정하기
+            </div>
+          )}
           <div
             onClick={() => {
               onDelete();
               setIsOpen(false);
             }}
-            className="hover:bg-primary-hover h-10 w-full cursor-pointer px-4 py-[11.5px] text-left"
+            className="hover:bg-danger h-10 w-full cursor-pointer px-4 py-[11.5px] text-left"
           >
             삭제하기
           </div>

--- a/src/components/teampage/Report.tsx
+++ b/src/components/teampage/Report.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Alert from '@/assets/icons/Alert';
 import ReportProgress from '@/components/teampage/ReportProgress';
@@ -69,7 +70,19 @@ function TaskReportColumn({ total, completed }: ReportProps) {
 }
 
 function NewestTask({ title, startDate }: NewestTaskProps) {
-  const elapsedTime = startDate ? formatElapsedTime(startDate) : '알 수 없음';
+  const [elapsedTime, setElapsedTime] = useState(() =>
+    startDate ? formatElapsedTime(startDate) : '알 수 없음'
+  );
+
+  useEffect(() => {
+    if (!startDate) return;
+
+    const interval = setInterval(() => {
+      setElapsedTime(formatElapsedTime(startDate));
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [startDate]);
 
   return (
     <div
@@ -85,7 +98,17 @@ function NewestTask({ title, startDate }: NewestTaskProps) {
 }
 
 function NewestTaskForMobile({ title, startDate }: NewestTaskProps) {
-  const elapsedTime = startDate ? formatElapsedTime(startDate) : '알 수 없음';
+  const [elapsedTime, setElapsedTime] = useState(() =>
+    startDate ? formatElapsedTime(startDate) : '알 수 없음'
+  );
+
+  useEffect(() => {
+    if (!startDate) return;
+    const interval = setInterval(() => {
+      setElapsedTime(formatElapsedTime(startDate));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [startDate]);
 
   return (
     <div className="bg-bg200 right-[28%] flex h-14 w-full items-center justify-start gap-4 rounded-xl pr-2">

--- a/src/components/teampage/TaskElements.tsx
+++ b/src/components/teampage/TaskElements.tsx
@@ -82,7 +82,6 @@ export function TaskListsItem({
   const updateMutation = useMutation({
     mutationFn: () => updateTaskList(groupId, taskListId, editName),
     onSuccess: () => {
-      toast.success('이름이 수정되었습니다.');
       queryClient.invalidateQueries({ queryKey: ['groupDetail', groupId] });
     },
     onError: () => toast.error('수정에 실패했습니다.'),


### PR DESCRIPTION
## ✨ 작업 내용

- 할일목록 & 멤버목록 페이지네이션
- 할일목록 생성시 인풋 제한 10글자
- 그룹생성, 할일목록 생성 성고 시 표시되는 토스트 삭제
- Newest Tasks 시간 실시간 카운트화
- 누락된 드롭다운메뉴의 수정하기 옵션 다시 추가
- 드롭다운메뉴의 삭제하기 hover 시 배경색 danger로 지정
- 빌드 시 에러 발생 여부 점검

## 🔍 관련 이슈

- 관련된 이슈 번호가 있다면 적어주세요. (`ex. #12`)

## 📝 변경사항

- 어떤 코드나 파일이 변경되었는지 요약해주세요.

## 📌 참고 사항

- 코드 리뷰 시 알아두면 좋을 사항이나 스크린샷이 있다면 여기에 작성해주세요.
