### PR TITLE
[Feat/Refactor] My page (profile uploader) / My history (no data UI)

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -48,6 +48,10 @@ export const getUserInfo = async (): Promise<ParsedUser & { teams: Team[] }> => 
   };
 };
 
+export const updateUserImage = async (image: string) => {
+  await axiosInstance.patch('/user', { image });
+};
+
 export const updateUserName = async (name: string) => {
   await axiosInstance.patch('/user', { nickname: name });
 };

--- a/src/app/(pages)/(main)/myhistory/page.tsx
+++ b/src/app/(pages)/(main)/myhistory/page.tsx
@@ -21,14 +21,21 @@ export default function MyHistoryPage() {
   if (error) return <div>오류 발생</div>;
 
   const grouped = groupTasksByDate(historyData.tasksDone);
+  const hasTasks = historyData.tasksDone?.length > 0;
 
   return (
-    <div className="flex flex-col gap-10 py-10">
+    <div className="flex flex-col gap-10 pt-10">
       <h1 className="text-xl-bold">마이 히스토리</h1>
 
-      {Object.entries(grouped).map(([date, tasks]) => (
-        <TaskHistoryByDate key={date} date={date} history={tasks} />
-      ))}
+      {hasTasks ? (
+        Object.entries(grouped).map(([date, tasks]) => (
+          <TaskHistoryByDate key={date} date={date} history={tasks} />
+        ))
+      ) : (
+        <div className="flex min-h-[calc(100dvh-164px)] items-center justify-center px-4">
+          <p className="text-gray500 text-md-medium text-center">아직 히스토리가 없습니다.</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(pages)/(main)/mypage/components/EditableProfileSection.tsx
+++ b/src/app/(pages)/(main)/mypage/components/EditableProfileSection.tsx
@@ -1,14 +1,12 @@
 'use client';
 
-import Button from '@/components/common/Button/Button';
-import ProfileUploader from '@/components/ProfileUploader';
-import { useEditProfileImage } from '@/hooks/useEditProfileImage';
 import { useEffect } from 'react';
 import { toast } from 'react-toastify';
+import ProfileUploader from '@/components/ProfileUploader';
+import { useEditProfileImage } from '@/hooks/useEditProfileImage';
 
-export default function EditableProfileSection() {
-  const { previewUrl, fileError, submitError, onFileChange, } =
-    useEditProfileImage();
+export default function EditableProfileSection({}) {
+  const { previewUrl, fileError, submitError, onFileChange } = useEditProfileImage();
 
   useEffect(() => {
     if (submitError) {

--- a/src/app/(pages)/(main)/mypage/components/EditableProfileSection.tsx
+++ b/src/app/(pages)/(main)/mypage/components/EditableProfileSection.tsx
@@ -1,10 +1,23 @@
-import { EditableProfile } from '@/components/common/Profiles';
-import { ProfileProps } from '@/types/profiletypes';
+'use client';
 
-export default function EditableProfileSection({ width }: ProfileProps) {
+import Button from '@/components/common/Button/Button';
+import ProfileUploader from '@/components/ProfileUploader';
+import { useEditProfileImage } from '@/hooks/useEditProfileImage';
+import { useEffect } from 'react';
+import { toast } from 'react-toastify';
+
+export default function EditableProfileSection() {
+  const { previewUrl, fileError, submitError, onFileChange, } =
+    useEditProfileImage();
+
+  useEffect(() => {
+    if (submitError) {
+      toast.error(submitError);
+    }
+  }, [submitError]);
   return (
-    <button className="w-fit">
-      <EditableProfile width={width} />
-    </button>
+    <div className="flex w-fit flex-col items-center gap-3">
+      <ProfileUploader fileUrl={previewUrl} error={fileError} onChange={onFileChange} />
+    </div>
   );
 }

--- a/src/app/(pages)/(main)/mypage/page.tsx
+++ b/src/app/(pages)/(main)/mypage/page.tsx
@@ -17,7 +17,7 @@ export default function MyPage() {
     <div className="mx-auto flex max-w-[792px] flex-col gap-6 py-10">
       <h2 className="text-2lg-bold">계정 설정</h2>
 
-      <EditableProfileSection width={64} />
+      <EditableProfileSection />
 
       <div className="flex flex-col gap-4">
         <EditableNameSection name={user.nickname} />

--- a/src/components/layout/Gnb/Headerconfig.ts
+++ b/src/components/layout/Gnb/Headerconfig.ts
@@ -31,6 +31,11 @@ const STATIC_HEADER_CONFIG: Record<string, HeaderVisibilityConfig> = {
     showFreeBoardLink: true,
     showProfile: true,
   },
+  '/myhistory': {
+    showTeamSelector: true,
+    showFreeBoardLink: true,
+    showProfile: true,
+  },
   '/': {
     showTeamSelector: true,
     showFreeBoardLink: true,

--- a/src/hooks/useEditProfileImage.ts
+++ b/src/hooks/useEditProfileImage.ts
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { uploadImage } from '@/api/TeamCreate';
+import { QUERY_KEYS } from '@/constants/queryKeys';
+import { updateUserImage } from '@/api/user';
+
+export function useEditProfileImage() {
+  const queryClient = useQueryClient();
+
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const MAX_SIZE = 10 * 1024 * 1024;
+
+  const onFileChange = async (file: File | null, err: string | null) => {
+    setFileError(err);
+    setSubmitError(null);
+
+    if (err || !file) {
+      setFile(null);
+      setPreviewUrl(null);
+      return;
+    }
+    if (file.size > MAX_SIZE) {
+      setFileError('10MB 이하만 가능합니다.');
+      setFile(null);
+      setPreviewUrl(null);
+      return;
+    }
+
+    setFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+
+    await onSubmit(file);
+  };
+
+  const onSubmit = async (fileToUpload: File | null = file) => {
+    if (!fileToUpload) return;
+
+    setIsLoading(true);
+    setSubmitError(null);
+
+    try {
+      const imageUrl = await uploadImage(fileToUpload);
+      await updateUserImage(imageUrl);
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.user.me,
+      });
+    } catch (err) {
+      if (err instanceof Error) {
+        setSubmitError(err.message || '이미지 수정 중 오류 발생');
+      } else {
+        setSubmitError('알 수 없는 오류가 발생했습니다.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const isDisabled = !!fileError || isLoading;
+
+  return {
+    previewUrl,
+    fileError,
+    submitError,
+    isDisabled,
+    isLoading,
+    onFileChange,
+    onSubmit,
+  };
+}


### PR DESCRIPTION
## ✨ 작업 내용

- 계정 설정 페이지: 프로필 이미지 수정 기능 적용
- 마이 히스토리 페이지: 히스토리 데이터가 없을 경우 UI 구현 & 헤더 설정

## 🔍 관련 이슈

- #75 
- #44 

## 📝 변경사항

- ProfileUploader 컴포넌트 사용 (useEditProfileImage.ts 훅 생성)
- 마이 히스토리 페이지 데이터가 없을 경우 화면 구현
- 마이 히스토리 headerConfig 설정

## 📌 참고 사항

- 코드 리뷰 시 알아두면 좋을 사항이나 스크린샷이 있다면 여기에 작성해주세요.
