### PR TITLE
[Feat] 팀수정 삭제 후 헤더 및 드롭다운 동기화 문제 해결

### DIFF
--- a/src/app/(pages)/(main)/[teamid]/edit/EditButton.tsx
+++ b/src/app/(pages)/(main)/[teamid]/edit/EditButton.tsx
@@ -1,17 +1,20 @@
+'use client';
+
 import { useParams, useRouter } from 'next/navigation';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Button from '@/components/common/Button/Button';
 import { patchGroup } from '@/api/group.api';
-import { useQueryClient } from '@tanstack/react-query';
 import { getUserInfo } from '@/api/user';
 import { useUserStore } from '@/stores/useUserStore';
 import { toast } from 'react-toastify';
+import { QUERY_KEYS } from '@/constants/queryKeys';
 
 interface EditButtonProps {
   name: string;
+  onSuccess?: () => void;
 }
 
-export default function EditButton({ name }: EditButtonProps) {
+export default function EditButton({ name, onSuccess }: EditButtonProps) {
   const { teamid } = useParams() as { teamid: string };
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -33,10 +36,14 @@ export default function EditButton({ name }: EditButtonProps) {
         teams: updatedUserInfo.teams,
       });
 
+      // 모든 관련 쿼리 invalidate
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.user.me });
       await queryClient.invalidateQueries({ queryKey: ['groupPageInfo', teamid] });
       await queryClient.invalidateQueries({ queryKey: ['groupDetail', Number(teamid)] });
 
       toast.success('팀 이름이 수정되었습니다.');
+
+      onSuccess?.(); //selectedTeam 업데이트 처리
 
       setTimeout(() => {
         router.push(`/${teamid}`);

--- a/src/app/(pages)/(main)/[teamid]/edit/page.tsx
+++ b/src/app/(pages)/(main)/[teamid]/edit/page.tsx
@@ -9,15 +9,26 @@ import EditButton from './EditButton';
 import { AuthPagesLayout, PageTitleStyle } from '@/styles/pageStyle';
 import { useGroupPageInfo } from '@/hooks/useGroupPageInfo';
 import { useGroupDetail } from '@/hooks/useGroupDetail';
+import { useSelectedTeamStore } from '@/stores/useSelectedTeamStore';
 
 export default function TeamEditPage() {
   const [teamName, setTeamName] = useState('');
-
   const { teamid } = useParams() as { teamid: string };
+
   const { data: userData } = useGroupPageInfo(teamid);
   const { data: groupDetail } = useGroupDetail(userData?.group.id);
 
+  const { selectedTeam, setSelectedTeam } = useSelectedTeamStore();
+
   if (!userData || !groupDetail) return null;
+
+  const handleSuccess = () => {
+    setSelectedTeam({
+      id: `${userData.group.id}`,
+      name: teamName,
+      image: groupDetail.image ?? null,
+    });
+  };
 
   return (
     <div className={clsx(AuthPagesLayout, 'mt-14')}>
@@ -28,7 +39,8 @@ export default function TeamEditPage() {
         <EditableTeamNameSection name={teamName} setName={setTeamName} />
       </div>
 
-      <EditButton name={teamName} />
+      <EditButton name={teamName} onSuccess={handleSuccess} />
+
       <p className="text-center text-sm md:text-base">
         팀 이름은 회사명이나 모임 이름 등으로 설정하면 좋아요.
       </p>

--- a/src/components/layout/Gnb/Header.tsx
+++ b/src/components/layout/Gnb/Header.tsx
@@ -45,7 +45,7 @@ export default function Header({ onOpenSideMenu }: HeaderProps) {
     }
   }, [userData, setUserInfo]);
 
-  // ✅ 새로고침 시 URL의 teamid로 selectedTeam 복원
+  // 새로고침 시 URL의 teamid로 selectedTeam 복원
   useEffect(() => {
     if (!selectedTeam && teams.length > 0 && teamid) {
       const matchedTeam = teams.find((t) => t.id === teamid);
@@ -55,7 +55,7 @@ export default function Header({ onOpenSideMenu }: HeaderProps) {
     }
   }, [selectedTeam, teams, teamid, setSelectedTeam]);
 
-  // ✅ 선택된 팀이 삭제되었거나 유효하지 않으면 fallback
+  // 선택된 팀이 삭제되었거나 유효하지 않으면 fallback
   useEffect(() => {
     if (teams && teams.length > 0) {
       const stillExists = teams.find((team) => team.id === selectedTeam?.id);

--- a/src/components/layout/Gnb/Header.tsx
+++ b/src/components/layout/Gnb/Header.tsx
@@ -2,6 +2,9 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
 import Logo from './Logo';
 import SideMenu from './SideMenu';
 import TeamSelector from './TeamSelector';
@@ -10,11 +13,8 @@ import { useHeader } from './HeaderContext';
 import { useUserStore } from '@/stores/useUserStore';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useSelectedTeamStore } from '@/stores/useSelectedTeamStore';
-import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { getUserInfo } from '@/api/user';
-import { useEffect } from 'react';
-import { TemplateContext } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 
 interface HeaderProps {
   onOpenSideMenu: () => void;
@@ -25,6 +25,7 @@ export default function Header({ onOpenSideMenu }: HeaderProps) {
   const accessToken = useAuthStore((s) => s.accessToken);
   const { teams, setUserInfo } = useUserStore();
   const { selectedTeam, setSelectedTeam } = useSelectedTeamStore();
+  const { teamid } = useParams() as { teamid: string };
 
   const { data: userData } = useQuery({
     queryKey: QUERY_KEYS.user.me,
@@ -33,6 +34,7 @@ export default function Header({ onOpenSideMenu }: HeaderProps) {
     enabled: !!accessToken,
   });
 
+  // 유저 정보 받아오면 상태 반영
   useEffect(() => {
     if (userData) {
       setUserInfo({
@@ -43,17 +45,27 @@ export default function Header({ onOpenSideMenu }: HeaderProps) {
     }
   }, [userData, setUserInfo]);
 
-  //teams 배열이 바뀔 때마다 selectedTeam 유효성 검사
+  // ✅ 새로고침 시 URL의 teamid로 selectedTeam 복원
+  useEffect(() => {
+    if (!selectedTeam && teams.length > 0 && teamid) {
+      const matchedTeam = teams.find((t) => t.id === teamid);
+      if (matchedTeam) {
+        setSelectedTeam(matchedTeam);
+      }
+    }
+  }, [selectedTeam, teams, teamid, setSelectedTeam]);
+
+  // ✅ 선택된 팀이 삭제되었거나 유효하지 않으면 fallback
   useEffect(() => {
     if (teams && teams.length > 0) {
       const stillExists = teams.find((team) => team.id === selectedTeam?.id);
       if (!stillExists) {
-        setSelectedTeam(teams[0]); // 현재 선택된 팀이 삭제된 경우, 첫 번째 팀으로 설정
+        setSelectedTeam(teams[0]); // fallback to 첫 번째 팀
       }
     } else {
-      setSelectedTeam(null); // 팀이 없는 경우 null로 초기화
+      setSelectedTeam(null);
     }
-  }, [teams]); // selectedTeam은 deps에서 제거 (의도적)
+  }, [teams]);
 
   return (
     <header className="bg-bg200 border-border sticky top-0 z-50 flex h-15 w-full justify-center border-b-1 py-[14px]">

--- a/src/components/layout/Gnb/SideMenu.tsx
+++ b/src/components/layout/Gnb/SideMenu.tsx
@@ -40,7 +40,7 @@ export default function SideMenu({ isOpen, onClose }: SideMenuProps) {
               {team.name}
             </div>
           ))}
-          <Link href="/articles" className="text-primary text-md-medium px-2 py-1">
+          <Link href="/boards" className="text-primary text-md-medium px-2 py-1">
             자유게시판
           </Link>
         </div>

--- a/src/components/layout/Gnb/TeamSelector.tsx
+++ b/src/components/layout/Gnb/TeamSelector.tsx
@@ -4,15 +4,27 @@ import Link from 'next/link';
 import { useState, useEffect } from 'react';
 import { useUserStore } from '@/stores/useUserStore';
 import { useSelectedTeamStore } from '@/stores/useSelectedTeamStore';
+import { useParams } from 'next/navigation';
 import SelectableDropdown from '@/components/dropdown/SelectableDropdown';
 import DropDownGroupsItem, { GroupOption } from '@/components/dropdown/Groups';
 
 export default function TeamSelector() {
   const teams = useUserStore((s) => s.teams) ?? [];
   const { selectedTeam, setSelectedTeam } = useSelectedTeamStore();
+  const { teamid } = useParams() as { teamid: string };
   const [value, setValue] = useState<string>(selectedTeam?.name ?? '팀 없음');
 
-  //selectedTeam 변경 시 드롭다운 텍스트도 자동 업데이트
+  // ✅ URL의 teamid와 현재 선택된 팀이 다르면 강제 동기화
+  useEffect(() => {
+    if (teams.length > 0 && teamid) {
+      const matchedTeam = teams.find((t) => t.id === teamid);
+      if (matchedTeam && selectedTeam?.id !== matchedTeam.id) {
+        setSelectedTeam(matchedTeam);
+      }
+    }
+  }, [teams, teamid, selectedTeam, setSelectedTeam]);
+
+  // selectedTeam이 바뀌면 드롭다운 텍스트도 바뀜
   useEffect(() => {
     if (selectedTeam) {
       setValue(selectedTeam.name);
@@ -21,7 +33,7 @@ export default function TeamSelector() {
     }
   }, [selectedTeam]);
 
-  //초기 selectedTeam이 없을 경우 첫 번째 팀 자동 설정
+  // fallback: 아무것도 없을 경우 첫 번째 팀 선택
   useEffect(() => {
     if (teams.length > 0 && !selectedTeam) {
       setSelectedTeam(teams[0]);
@@ -40,11 +52,11 @@ export default function TeamSelector() {
 
     return (
       <DropDownGroupsItem
-        key={group.id}
+        key={`${group.id}-${group.name}`}
         group={group}
         onClick={() => {
           setSelectedTeam(team);
-          setValue(team.name); // 직접 선택했을 때도 value 갱신
+          setValue(team.name);
         }}
       />
     );

--- a/src/components/layout/Gnb/TeamSelector.tsx
+++ b/src/components/layout/Gnb/TeamSelector.tsx
@@ -14,7 +14,7 @@ export default function TeamSelector() {
   const { teamid } = useParams() as { teamid: string };
   const [value, setValue] = useState<string>(selectedTeam?.name ?? '팀 없음');
 
-  // ✅ URL의 teamid와 현재 선택된 팀이 다르면 강제 동기화
+  //URL의 teamid와 현재 선택된 팀이 다르면 강제 동기화
   useEffect(() => {
     if (teams.length > 0 && teamid) {
       const matchedTeam = teams.find((t) => t.id === teamid);


### PR DESCRIPTION
## ✨ 작업 내용

- EditButton.tsx에서 팀 이름 수정 성공시 드롭다운에 반영 및 헤더에 반영되도록 함
- 팀 이름 변경 후에도 이전 팀이름이 드롭다운 목록에 남는 문제 해결
- 팀 생성이후에 생성된 팀으로 이동시에 헤더에 팀이름 표시가 안되던 문제 해결
## 🔍 관련 이슈

- #23 

## 📝 변경사항

- TeamSelector.tsx에서 현재 URL의 teamid와 selectedteam의 id가 다르면 팀을 다시 설정하도록 useeffect 추가

## 📌 참고 사항

- ![image](https://github.com/user-attachments/assets/5094ecf1-35d9-4500-bf1c-ca1df8b7fa68)

