### PR TITLE
[Feat] Dropdown, sideMenu

### DIFF
--- a/src/components/dropdown/BaseDropdown.tsx
+++ b/src/components/dropdown/BaseDropdown.tsx
@@ -1,4 +1,3 @@
-// src/components/dropdown/BaseDropdown.tsx
 'use client';
 
 import React, { useState } from 'react';
@@ -14,6 +13,10 @@ export interface DropDownProps {
   dropDownOpenBtn?: React.ReactNode;
   footerBtn?: React.ReactNode;
   placement: string;
+
+  //외부 제어용
+  isOpen?: boolean;
+  setIsOpen?: (open: boolean) => void;
 }
 
 export default function DropDown({
@@ -23,8 +26,15 @@ export default function DropDown({
   size,
   footerBtn = null,
   placement,
+  isOpen: controlledIsOpen,
+  setIsOpen: setControlledIsOpen,
 }: DropDownProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  // 언컨트롤드 fallback
+  const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(false);
+
+  const isOpen = controlledIsOpen !== undefined ? controlledIsOpen : uncontrolledIsOpen;
+  const setIsOpen = setControlledIsOpen ?? setUncontrolledIsOpen;
+
   const hashedIndex = size.charCodeAt(0) % options.length;
 
   const handleClickOption = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -32,22 +42,26 @@ export default function DropDown({
     onSelect?.(e);
   };
 
+  const handleToggleOpen = () => {
+    setIsOpen(!isOpen);
+  };
+
   return (
     <div className="relative overflow-visible">
-      {' '}
       {/* overflow-visible로 부모가 자식 잘림 방지 */}
-      <div className="cursor-pointer" onClick={() => setIsOpen((prev) => !prev)}>
+      <div className="cursor-pointer" onClick={handleToggleOpen}>
         {dropDownOpenBtn}
       </div>
+
       {isOpen && (
         <div
           className={clsx(
-            'bg-bg200 border-bg100 absolute z-50 rounded-lg border', // z-50로 수정
+            'bg-bg200 border-bg100 absolute z-50 rounded-lg border',
             size === 'xl' && 'h-fit px-4 py-4',
             footerBtn && 'flex flex-col gap-4',
             placement
           )}
-          style={{ overflow: 'visible' }} // 메뉴 내 자식 요소도 잘리지 않도록
+          style={{ overflow: 'visible' }}
         >
           <div className="scroll-area max-h-120 overflow-auto">
             {options.map((option, idx) => (

--- a/src/components/dropdown/SelectableDropdown.tsx
+++ b/src/components/dropdown/SelectableDropdown.tsx
@@ -11,6 +11,10 @@ interface SelectableDropdownProps extends DropDownProps {
   value?: string;
   /** 컨트롤드 모드: 값이 바뀔 때 호출되는 콜백 (new label) */
   onChange?: (newValue: string) => void;
+  /** 드롭다운 열림 여부 (외부 제어용) */
+  isOpen?: boolean;
+  /** 드롭다운 열림 상태 setter (외부 제어용) */
+  setIsOpen?: (open: boolean) => void;
 }
 
 export default function SelectableDropdown({
@@ -21,32 +25,42 @@ export default function SelectableDropdown({
   defaultValue,
   value: controlledValue,
   onChange,
-  onSelect, // BaseDropdown 으로 내려가는 기존 콜백
+  onSelect,
+  isOpen,
+  setIsOpen,
 }: SelectableDropdownProps) {
-  // 내부 언컨트롤드 상태
   const [uncontrolledSelected, setUncontrolledSelected] = useState<string>(
     defaultValue ?? (typeof options[0] === 'string' ? options[0] : '')
   );
 
-  // 실제로 보여줄 텍스트: 컨트롤드가 주어지면 그걸, 아니면 언컨트롤드
   const currentSelected = controlledValue !== undefined ? controlledValue : uncontrolledSelected;
 
   const handleClickOption = (e: React.MouseEvent<HTMLDivElement>) => {
     const newLabel = e.currentTarget.textContent ?? '';
 
-    // 1) 언컨트롤드 모드라면 내부 상태 업데이트
     if (controlledValue === undefined) {
       setUncontrolledSelected(newLabel);
     }
-    // 2) 컨트롤드 모드라면 상위 onChange 콜백 호출
+
     onChange?.(newLabel);
-    // 3) 기존 onSelect 콜백도 전달
     onSelect?.(e);
+
+    // 항목 선택 후 드롭다운 닫기
+    setIsOpen?.(false);
+  };
+
+  const handleClickOpenBtn = () => {
+    setIsOpen?.(!isOpen);
   };
 
   return (
     <BaseDropdown
-      dropDownOpenBtn={<DropDownOpenBtn size={size} currentSelected={currentSelected} />}
+      dropDownOpenBtn={
+        <div onClick={handleClickOpenBtn}>
+          <DropDownOpenBtn size={size} currentSelected={currentSelected} />
+        </div>
+      }
+      isOpen={isOpen}
       onSelect={handleClickOption}
       options={options}
       size={size}

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -65,7 +65,7 @@ export default function LandingHeader({ topImageSrc }: LandingHeaderProps) {
 
       <button
         onClick={handleStartClick}
-        className="bg-gradient-primary text-text-inverse absolute bottom-[48px] h-[45px] w-[343px] rounded-[32px] text-lg font-bold md:bottom-[119px] md:w-[373px] lg:bottom-[120px] lg:w-[373px]"
+        className={`bg-gradient-primary text-text-inverse fixed bottom-4 left-1/2 z-50 h-[45px] w-[343px] -translate-x-1/2 rounded-[32px] text-lg font-bold sm:absolute sm:bottom-[119px] sm:left-auto sm:translate-x-0 md:w-[373px] lg:bottom-[120px]`}
       >
         지금 시작하기
       </button>

--- a/src/components/layout/Gnb/ProfileSelector.tsx
+++ b/src/components/layout/Gnb/ProfileSelector.tsx
@@ -2,15 +2,22 @@
 
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { useRef, useState } from 'react';
 import DropDown from '@/components/dropdown/BaseDropdown';
 import DropDownProfileItemList from '@/components/dropdown/ProfileItemList';
 import { useUserStore } from '@/stores/useUserStore';
 import { useAuthStore } from '@/stores/useAuthStore';
+import useClickOutside from '@/hooks/useClickOutside';
 
 export default function ProfileDropdown() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
   const { nickname } = useUserStore();
   const { logout } = useAuthStore();
   const router = useRouter();
+
+  useClickOutside(ref, () => setIsOpen(false));
 
   const handleSelect = (e: React.MouseEvent<HTMLDivElement>) => {
     const selected = e.currentTarget.textContent?.trim();
@@ -18,22 +25,25 @@ export default function ProfileDropdown() {
       logout();
       router.push('/');
     }
+    setIsOpen(false); //선택 시 드롭다운 닫기
   };
 
   return (
-    <DropDown
-      size="lg"
-      placement="top-6 mt-2 right-0"
-      dropDownOpenBtn={
-        <button className="flex items-center gap-2">
-          <Image src="/icons/profile.svg" alt="유저 아이콘" width={24} height={24} />
-          <span className="text-md-md hidden lg:inline">
-            {nickname ?? '...'} {/* fallback 처리 */}
-          </span>
-        </button>
-      }
-      options={DropDownProfileItemList}
-      onSelect={handleSelect}
-    />
+    <div ref={ref}>
+      <DropDown
+        size="lg"
+        placement="top-6 mt-2 right-0"
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        dropDownOpenBtn={
+          <button className="flex items-center gap-2">
+            <Image src="/icons/profile.svg" alt="유저 아이콘" width={24} height={24} />
+            <span className="text-md-md hidden lg:inline">{nickname ?? '...'}</span>
+          </button>
+        }
+        options={DropDownProfileItemList}
+        onSelect={handleSelect}
+      />
+    </div>
   );
 }

--- a/src/components/layout/Gnb/SideMenu.tsx
+++ b/src/components/layout/Gnb/SideMenu.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useUserStore } from '@/stores/useUserStore';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 
 interface SideMenuProps {
   isOpen: boolean;
@@ -14,6 +14,7 @@ interface SideMenuProps {
 export default function SideMenu({ isOpen, onClose }: SideMenuProps) {
   const { teams } = useUserStore();
   const router = useRouter();
+  const pathname = usePathname();
 
   if (!isOpen) return null;
 
@@ -21,6 +22,8 @@ export default function SideMenu({ isOpen, onClose }: SideMenuProps) {
     router.push(`/${teamId}`);
     onClose();
   };
+
+  const isFreeBoardSelected = pathname === '/boards';
 
   return (
     <>
@@ -31,16 +34,26 @@ export default function SideMenu({ isOpen, onClose }: SideMenuProps) {
         </button>
 
         <div className="flex flex-col gap-6">
-          {teams.map((team) => (
-            <div
-              key={team.id}
-              className="text-md-medium hover:bg-bg300 cursor-pointer rounded px-2 py-1"
-              onClick={() => handleTeamClick(team.id)}
-            >
-              {team.name}
-            </div>
-          ))}
-          <Link href="/boards" className="text-primary text-md-medium px-2 py-1">
+          {teams.map((team) => {
+            const isSelected = pathname === `/${team.id}`;
+            return (
+              <div
+                key={team.id}
+                className={`text-md-medium cursor-pointer rounded px-2 py-1 ${isSelected ? 'text-primary font-bold' : 'hover:bg-bg300 text-white'} `}
+                onClick={() => handleTeamClick(team.id)}
+              >
+                {team.name}
+              </div>
+            );
+          })}
+
+          <Link
+            href="/boards"
+            className={`text-md-medium rounded px-2 py-1 ${
+              isFreeBoardSelected ? 'text-primary font-bold' : 'hover:bg-bg300 text-white'
+            }`}
+            onClick={onClose}
+          >
             자유게시판
           </Link>
         </div>

--- a/src/components/layout/Gnb/TeamSelector.tsx
+++ b/src/components/layout/Gnb/TeamSelector.tsx
@@ -1,20 +1,26 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, useEffect } from 'react';
+import { useRef, useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
 import { useUserStore } from '@/stores/useUserStore';
 import { useSelectedTeamStore } from '@/stores/useSelectedTeamStore';
-import { useParams } from 'next/navigation';
 import SelectableDropdown from '@/components/dropdown/SelectableDropdown';
 import DropDownGroupsItem, { GroupOption } from '@/components/dropdown/Groups';
+import useClickOutside from '@/hooks/useClickOutside';
 
 export default function TeamSelector() {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
   const teams = useUserStore((s) => s.teams) ?? [];
   const { selectedTeam, setSelectedTeam } = useSelectedTeamStore();
   const { teamid } = useParams() as { teamid: string };
   const [value, setValue] = useState<string>(selectedTeam?.name ?? '팀 없음');
 
-  //URL의 teamid와 현재 선택된 팀이 다르면 강제 동기화
+  // 바깥 클릭 시 드롭다운 닫기
+  useClickOutside(dropdownRef, () => setIsOpen(false));
+
+  // URL과 상태 동기화
   useEffect(() => {
     if (teams.length > 0 && teamid) {
       const matchedTeam = teams.find((t) => t.id === teamid);
@@ -24,7 +30,7 @@ export default function TeamSelector() {
     }
   }, [teams, teamid, selectedTeam, setSelectedTeam]);
 
-  // selectedTeam이 바뀌면 드롭다운 텍스트도 바뀜
+  // selectedTeam → 드롭다운 값 반영
   useEffect(() => {
     if (selectedTeam) {
       setValue(selectedTeam.name);
@@ -33,7 +39,7 @@ export default function TeamSelector() {
     }
   }, [selectedTeam]);
 
-  // fallback: 아무것도 없을 경우 첫 번째 팀 선택
+  // fallback: 팀 없음 → 첫 번째 팀 선택
   useEffect(() => {
     if (teams.length > 0 && !selectedTeam) {
       setSelectedTeam(teams[0]);
@@ -57,26 +63,34 @@ export default function TeamSelector() {
         onClick={() => {
           setSelectedTeam(team);
           setValue(team.name);
+          setIsOpen(false); // 항목 선택 시 드롭다운 닫기
         }}
       />
     );
   });
 
   return (
-    <SelectableDropdown
-      placement="top-10 mt-2"
-      size="xl"
-      value={value}
-      onChange={setValue}
-      options={options}
-      footerBtn={
-        <Link
-          href="/addteam"
-          className="flex h-12 w-46 items-center justify-center rounded-xl border border-white text-white"
-        >
-          + 팀 추가하기
-        </Link>
-      }
-    />
+    <div ref={dropdownRef}>
+      <SelectableDropdown
+        placement="top-10 mt-2"
+        size="xl"
+        value={value}
+        onChange={(v) => {
+          setValue(v);
+          setIsOpen((prev) => !prev);
+        }}
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        options={options}
+        footerBtn={
+          <Link
+            href="/addteam"
+            className="flex h-12 w-46 items-center justify-center rounded-xl border border-white text-white"
+          >
+            + 팀 추가하기
+          </Link>
+        }
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## ✨ 작업 내용

-  header Dropdown 이 다른 위치를 클릭시 자동으로 닫히게 설정하였습니다.
-  모바일 sideMenu에서 어떤 페이지가 선택되어 있는지 알수 없는 가시성을 개선하였습니다.
-  landingpage에서 지금시작하기 버튼이 모바일 기기에서 더욱 잘보이게 하단에 고정하였습니다.
## 🔍 관련 이슈

- #22 
- #33 

## 📝 변경사항

- 어떤 코드나 파일이 변경되었는지 요약해주세요.

## 📌 참고 사항

- ![image](https://github.com/user-attachments/assets/6c5ebac0-ad8c-4df7-b3e7-94ff42254514)
- ![image](https://github.com/user-attachments/assets/e9de9e0c-e845-4986-ad87-eb25d8e782af)

